### PR TITLE
Support Win64 builds in irrXML

### DIFF
--- a/src/irrTypes.h
+++ b/src/irrTypes.h
@@ -79,7 +79,7 @@ typedef unsigned short wchar_t;
 #endif // microsoft compiler
 
 //! define a break macro for debugging only in Win32 mode.
-#if defined(WIN32) && defined(_MSC_VER) && defined(_DEBUG)
+#if !defined(WIN64) && defined(WIN32) && defined(_MSC_VER) && defined(_DEBUG)
 #define _IRR_DEBUG_BREAK_IF( _CONDITION_ ) if (_CONDITION_) {_asm int 3}
 #else 
 #define _IRR_DEBUG_BREAK_IF( _CONDITION_ )
@@ -91,7 +91,7 @@ When you call unmanaged code that returns a bool type value of false from manage
 the return value may appear as true. See 
 http://support.microsoft.com/default.aspx?kbid=823071 for details. 
 Compiler version defines: VC6.0 : 1200, VC7.0 : 1300, VC7.1 : 1310, VC8.0 : 1400*/
-#if defined(WIN32) && defined(_MSC_VER) && (_MSC_VER > 1299) && (_MSC_VER < 1400)
+#if !defined(WIN64) && defined(WIN32) && defined(_MSC_VER) && (_MSC_VER > 1299) && (_MSC_VER < 1400)
 #define _IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX __asm mov eax,100
 #else
 #define _IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX

--- a/src/irrTypes.h
+++ b/src/irrTypes.h
@@ -79,7 +79,7 @@ typedef unsigned short wchar_t;
 #endif // microsoft compiler
 
 //! define a break macro for debugging only in Win32 mode.
-#if !defined(WIN64) && defined(WIN32) && defined(_MSC_VER) && defined(_DEBUG)
+#if !defined(_WIN64) && defined(WIN32) && defined(_MSC_VER) && defined(_DEBUG)
 #define _IRR_DEBUG_BREAK_IF( _CONDITION_ ) if (_CONDITION_) {_asm int 3}
 #else 
 #define _IRR_DEBUG_BREAK_IF( _CONDITION_ )
@@ -91,7 +91,7 @@ When you call unmanaged code that returns a bool type value of false from manage
 the return value may appear as true. See 
 http://support.microsoft.com/default.aspx?kbid=823071 for details. 
 Compiler version defines: VC6.0 : 1200, VC7.0 : 1300, VC7.1 : 1310, VC8.0 : 1400*/
-#if !defined(WIN64) && defined(WIN32) && defined(_MSC_VER) && (_MSC_VER > 1299) && (_MSC_VER < 1400)
+#if !defined(_WIN64) && defined(WIN32) && defined(_MSC_VER) && (_MSC_VER > 1299) && (_MSC_VER < 1400)
 #define _IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX __asm mov eax,100
 #else
 #define _IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX


### PR DESCRIPTION
@ruslo irrXML uses `__asm`, which isn't supported in 64-bit MSVC builds. I've added a check to disable it.